### PR TITLE
Issue-34: Docker Compose Container Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM clojure:alpine
+RUN apk update \
+  && apk add nodejs=6.7.0-r0
+RUN mkdir -p /usr/src/app
+
+COPY / /usr/src/app/
+WORKDIR /usr/src/app
+
+RUN ["npm", "install"]
+RUN ["npm", "install", "-g", "grunt-cli"]
+RUN ["lein", "clean"]
+RUN ["lein", "cljsbuild", "once"]
+RUN ["grunt", "less"]
+
+CMD ["node", "server.js", "8080"]
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,78 @@
-FROM clojure:alpine
-RUN apk update \
-  && apk add nodejs=6.7.0-r0
+FROM node:7.1.0-alpine
+
+
+
+# Java
+# A few problems with compiling Java from source:
+#  1. Oracle.  Licensing prevents us from redistributing the official JDK.
+#  2. Compiling OpenJDK also requires the JDK to be installed, and it gets
+#       really hairy.
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+# add a simple script that can auto-detect the appropriate JAVA_HOME value
+# based on whether the JDK or only the JRE is installed
+RUN { \
+    echo '#!/bin/sh'; \
+    echo 'set -e'; \
+    echo; \
+    echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
+  } > /usr/local/bin/docker-java-home \
+  && chmod +x /usr/local/bin/docker-java-home
+ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk/jre
+ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
+
+ENV JAVA_VERSION 8u111
+ENV JAVA_ALPINE_VERSION 8.111.14-r0
+
+RUN set -x \
+  && apk add --no-cache \
+    openjdk8-jre="$JAVA_ALPINE_VERSION" \
+&& [ "$JAVA_HOME" = "$(docker-java-home)" ]
+
+
+# Clojure
+ENV LEIN_VERSION=2.7.1
+ENV LEIN_INSTALL=/usr/local/bin/
+
+WORKDIR /tmp
+
+# Install real tar as BusyBox's doesn't support --strip-components
+RUN apk add --update tar gnupg bash openssl && rm -rf /var/cache/apk/*
+
+# Download the whole repo as an archive
+RUN mkdir -p $LEIN_INSTALL \
+  && wget -q https://github.com/technomancy/leiningen/archive/$LEIN_VERSION.tar.gz \
+  && echo "Comparing archive checksum ..." \
+  && echo "876221e884780c865c2ce5c9aa5675a7cae9f215 *$LEIN_VERSION.tar.gz" | sha1sum -c - \
+
+  && mkdir ./leiningen \
+  && tar -xzf $LEIN_VERSION.tar.gz  -C ./leiningen/ --strip-components=1 \
+  && mv leiningen/bin/lein-pkg $LEIN_INSTALL/lein \
+  && rm -rf $LEIN_VERSION.tar.gz ./leiningen \
+
+  && chmod 0755 $LEIN_INSTALL/lein \
+
+# Download and verify Lein stand-alone jar
+  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip \
+  && wget -q https://github.com/technomancy/leiningen/releases/download/$LEIN_VERSION/leiningen-$LEIN_VERSION-standalone.zip.asc \
+
+  && gpg --keyserver pool.sks-keyservers.net --recv-key 2E708FB2FCECA07FF8184E275A92E04305696D78 \
+  && echo "Verifying Jar file signature ..." \
+  && gpg --verify leiningen-$LEIN_VERSION-standalone.zip.asc \
+
+# Put the jar where lein script expects
+  && rm leiningen-$LEIN_VERSION-standalone.zip.asc \
+  && mkdir -p /usr/share/java \
+  && mv leiningen-$LEIN_VERSION-standalone.zip /usr/share/java/leiningen-$LEIN_VERSION-standalone.jar
+
+ENV PATH=$PATH:$LEIN_INSTALL
+ENV LEIN_ROOT 1
+RUN lein
+
+
+# CTIA-UI
 RUN mkdir -p /usr/src/app
 
 COPY / /usr/src/app/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ grunt watch
 node server.js 6886
 ```
 
+## Development environment with docker-compose
+
+A docker-compose development environment, including ES, Redis, and CTIA is available:
+
+1. checkout CTIA on github:
+
+`git clone git@github.com:threatgrid/ctia.git`
+
+2. build the jar:
+
+`cd ctia && lein uberjar`
+
+3. build CTIA docker container:
+
+`docker build -t threatgrid/ctia:latest .`
+
+4. launch the compose receipe:
+
+```bash
+cd <ctia-ui-project-path>
+docker-compose -f containers/dev/docker-compose.yml up
+```
+
+5. change `tenzin-base-uri` to `http://127.0.0.1:3000/ctia` 
+
+
 ## Tenzin Docker Demo
 
 A simple Docker container is available for testing:
@@ -38,7 +64,6 @@ A simple Docker container is available for testing:
 ### Run
 
 `docker run -t -p 8080:8080 threatgrid/ctia-ui`
-
 
 ## License (TBD)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ grunt watch
 node server.js 6886
 ```
 
+## Tenzin Docker Demo
+
+A simple Docker container is available for testing:
+
+### Build
+
+`docker build -t threatgrid/ctia-ui:latest .`
+
+### Run
+
+`docker run -t -p 8080:8080 threatgrid/ctia-ui`
+
+
 ## License (TBD)
 
 Copyright (c) Cisco Systems. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -27,43 +27,53 @@ grunt watch
 node server.js 6886
 ```
 
-## Development environment with docker-compose
+## Launch a CTIA-UI demo via docker-compose
 
-A docker-compose development environment, including ES, Redis, and CTIA is available:
+A docker-compose demo environment, including ES, Redis, CTIA, and the CTIA-UI is available:
 
-1. checkout CTIA on github:
+1. Clone into the CTIA repository on github:
 
    `git clone git@github.com:threatgrid/ctia.git`
 
-2. build the jar:
+2. Build the CTIA uberjar:
 
    `cd ctia && lein uberjar`
 
-3. build CTIA docker container:
+3. Build CTIA docker container:
 
    `docker build -t threatgrid/ctia:latest .`
 
-4. launch the compose receipe:
+4. Launch the CTIA-UI via docker-compose:
+
+   ```bash
+      cd <ctia-ui-project-path>
+      docker-compose -f containers/demo/docker-compose.yml up
+   ```
+
+## Launch dev container via docker-compose
+
+A docker-compose development environment, including ES, Redis, and CTIA is available:
+
+1. Clone into the CTIA repository on github:
+
+   `git clone git@github.com:threatgrid/ctia.git`
+
+2. Build the CTIA uberjar:
+
+   `cd ctia && lein uberjar`
+
+3. Build CTIA docker container:
+
+   `docker build -t threatgrid/ctia:latest .`
+
+4. Launch the CTIA-UI via docker-compose:
 
    ```bash
       cd <ctia-ui-project-path>
       docker-compose -f containers/dev/docker-compose.yml up
    ```
 
-5. change `tenzin-base-uri` to `http://127.0.0.1:3000/ctia` 
-
-
-## Tenzin Docker Demo
-
-A simple Docker container is available for testing:
-
-### Build
-
-`docker build -t threatgrid/ctia-ui:latest .`
-
-### Run
-
-`docker run -t -p 8080:8080 threatgrid/ctia-ui`
+5. Launch CTIA-UI in your development environment and use http://localhost:3000 as your CTIA server.
 
 ## License (TBD)
 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,22 @@ A docker-compose development environment, including ES, Redis, and CTIA is avail
 
 1. checkout CTIA on github:
 
-`git clone git@github.com:threatgrid/ctia.git`
+   `git clone git@github.com:threatgrid/ctia.git`
 
 2. build the jar:
 
-`cd ctia && lein uberjar`
+   `cd ctia && lein uberjar`
 
 3. build CTIA docker container:
 
-`docker build -t threatgrid/ctia:latest .`
+   `docker build -t threatgrid/ctia:latest .`
 
 4. launch the compose receipe:
 
-```bash
-cd <ctia-ui-project-path>
-docker-compose -f containers/dev/docker-compose.yml up
-```
+   ```bash
+      cd <ctia-ui-project-path>
+      docker-compose -f containers/dev/docker-compose.yml up
+   ```
 
 5. change `tenzin-base-uri` to `http://127.0.0.1:3000/ctia` 
 

--- a/containers/demo/docker-compose.yml
+++ b/containers/demo/docker-compose.yml
@@ -1,5 +1,12 @@
 version: "2"
 services:
+  ctia-ui:
+    image: ctia-ui:latest
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
   redis-dev:
     image: redis
     ports:

--- a/containers/dev/docker-compose.yml
+++ b/containers/dev/docker-compose.yml
@@ -1,0 +1,25 @@
+redis-dev:
+  image: redis
+  ports:
+    - "6379:6379"
+elasticsearch-dev:
+  image: elasticsearch:2.3.3
+  command: "elasticsearch -Des.cluster.name=elasticsearch -Des.node.master=true"
+  ports:
+    - "9200:9200"
+    - "9300:9300"
+kibana-dev:
+  image: kibana:4.5.1
+  ports:
+    - "5601:5601"
+  environment:
+    - ELASTICSEARCH_URL=http://elasticsearch-dev:9200
+  links:
+    - elasticsearch-dev
+ctia-dev:
+  image: threatgrid/ctia:latest
+  ports:
+    - 3000:3000
+  command: java -Xmx4g -Djava.awt.headless=true -Dctia.store.es.default.host=elasticsearch-dev -server -cp ctia.jar:resources:. clojure.main -m ctia.main
+  links:
+    - elasticsearch-dev


### PR DESCRIPTION
The docker-compose file is now set to use version 2, allowing us to
build the ctia-ui container directly from within the composition.

This Dockerfile uses the officially supported alpine-node container
as its base, and extends it using code from the officially supported
container for alpine-clojure, so that we have a clean and robust base
system founded on best practices upon which to run the CTIA-UI.

Closes #34 